### PR TITLE
refactor: project id 로 이동하는 useeffect 로직 분리하기

### DIFF
--- a/src/pages/project/Project.tsx
+++ b/src/pages/project/Project.tsx
@@ -18,12 +18,15 @@ export default function Project() {
     const { id } = useParams()
     const container = useRef<HTMLDivElement>(null)
     useEffect(() => {
+        if (container.current) {
+            container.current.style.display = 'block'
+        }
+    }, [])
+
+    useEffect(() => {
         if (id) {
             const idElem = document.getElementById(id)
             if (idElem) idElem.scrollIntoView({ behavior: 'auto' })
-        }
-        if (container.current) {
-            container.current.style.display = 'block'
         }
     }, [id])
 


### PR DESCRIPTION
- project div id 값으로 콘텐츠 이동하는 로직에서 오류 발생하여 관련 로직 useEffect 2개로 분리하여 dependency 에 따라 관리해주기 